### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/AndreiAkhrymenkoDevOps/84de9f99-d4aa-4454-b7f1-95bad305ca73/c12d59ca-4a1d-4b0b-a0ee-c6fee1c839f1/_apis/work/boardbadge/75c32206-b9ae-40af-aadf-b645a83b2c07)](https://dev.azure.com/AndreiAkhrymenkoDevOps/84de9f99-d4aa-4454-b7f1-95bad305ca73/_boards/board/t/c12d59ca-4a1d-4b0b-a0ee-c6fee1c839f1/Microsoft.RequirementCategory)
 # MyProject


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#187](https://dev.azure.com/AndreiAkhrymenkoDevOps/84de9f99-d4aa-4454-b7f1-95bad305ca73/_workitems/edit/187). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.